### PR TITLE
Unify Output Debug Logging with slog-Based Logger

### DIFF
--- a/internal/output/errors.go
+++ b/internal/output/errors.go
@@ -11,6 +11,8 @@ package output
 
 import (
 	"fmt"
+
+	"github.com/gifflet/ccmd/pkg/logger"
 )
 
 // UserError represents an error that should be displayed to the user
@@ -59,7 +61,7 @@ func PrintUserError(err error) {
 			PrintErrorf("Details: %s", ue.Details)
 		}
 		if ue.Err != nil {
-			Debugf("Underlying error: %v", ue.Err)
+			logger.Debugf("Underlying error: %v", ue.Err)
 		}
 	} else {
 		PrintErrorf("Error: %v", err)

--- a/internal/output/migration.go
+++ b/internal/output/migration.go
@@ -48,7 +48,6 @@ func DebugError(err error, context string) {
 	}
 
 	logger.WithError(err).WithField("context", context).Debug("error occurred")
-	Debugf("%s: %v", context, err)
 }
 
 // LogAndPrintf logs at the appropriate level and prints to output

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -64,10 +64,3 @@ func Prompt(prompt string) string {
 	_, _ = fmt.Scanln(&input)
 	return input
 }
-
-// Debugf prints a debug message if debug mode is enabled.
-func Debugf(format string, a ...interface{}) {
-	if os.Getenv("CCMD_DEBUG") == "1" {
-		_, _ = fmt.Fprintf(os.Stderr, "[DEBUG] "+format+"\n", a...)
-	}
-}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 )
 
 // Fields represents structured fields for logging
@@ -44,8 +45,18 @@ type logger struct {
 // New creates a new logger instance
 func New() Logger {
 	level := slog.LevelInfo
-	if os.Getenv("CCMD_DEBUG") == "1" || os.Getenv("CCMD_LOG_LEVEL") == "debug" {
-		level = slog.LevelDebug
+
+	if envLevel := os.Getenv("CCMD_LOG_LEVEL"); envLevel != "" {
+		switch strings.ToLower(envLevel) {
+		case "debug":
+			level = slog.LevelDebug
+		case "info":
+			level = slog.LevelInfo
+		case "warn", "warning":
+			level = slog.LevelWarn
+		case "error":
+			level = slog.LevelError
+		}
 	}
 
 	opts := &slog.HandlerOptions{


### PR DESCRIPTION
This PR finalizes the migration to the new slog-based logger by removing the legacy Debugf function from the output package. Key changes:

- Removed Debugf and its conditional CCMD_DEBUG check
- Replaced all internal calls to Debugf with logger.Debugf
- Enhanced environment variable support in logger initialization for broader level control (CCMD_LOG_LEVEL=warn, error, etc.)